### PR TITLE
Improve security with password hashing

### DIFF
--- a/Datos/ClinicaContext.cs
+++ b/Datos/ClinicaContext.cs
@@ -1,24 +1,49 @@
 ﻿using Microsoft.EntityFrameworkCore;
-using MiSalud.Entidades; // Ajusta esto al namespace donde están tus modelos
+using MiSalud.Entidades;
+using Microsoft.Extensions.Configuration;
 
 namespace MiSalud.Datos
 {
     public class ClinicaContext : DbContext
     {
-        // DbSet para las entidades de la base de datos
+        // DbSets para las entidades de la base de datos
         public DbSet<Personal> Personal { get; set; }
-        // DbSet para la entidad Especialidad
         public DbSet<Especialidad> Especialidades { get; set; }
-
-        // Aquí puedes agregar otras tablas (DbSet)
-        // public DbSet<Paciente> Pacientes { get; set; }
+        public DbSet<Paciente> Pacientes { get; set; }
+        public DbSet<Consulta> Consultas { get; set; }
+        public DbSet<ConsultaServicio> ConsultasServicios { get; set; }
+        public DbSet<CuotaPlanPago> CuotasPlanPago { get; set; }
+        public DbSet<Factura> Facturas { get; set; }
+        public DbSet<FichaClinico> FichasClinico { get; set; }
+        public DbSet<Habitacion> Habitaciones { get; set; }
+        public DbSet<Hospitalizacion> Hospitalizaciones { get; set; }
+        public DbSet<HospitalizacionServicio> HospitalizacionServicios { get; set; }
+        public DbSet<HuellaDactilar> HuellasDactilares { get; set; }
+        public DbSet<MetodoPago> MetodosPago { get; set; }
+        public DbSet<Pago> Pagos { get; set; }
+        public DbSet<PlanPago> PlanesPago { get; set; }
+        public DbSet<Servicio> Servicios { get; set; }
+        public DbSet<TipoAlta> TiposAlta { get; set; }
+        public DbSet<TipoHabitacion> TiposHabitacion { get; set; }
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
             if (!optionsBuilder.IsConfigured)
             {
-                // Cambia la cadena de conexión según tu base de datos PostgreSQL
-                optionsBuilder.UseNpgsql("Host=localhost;Database=MiSalud;Username=postgres;Password=1234");
+                var configuration = new ConfigurationBuilder()
+                    .SetBasePath(AppDomain.CurrentDomain.BaseDirectory)
+                    .AddJsonFile("appsettings.json", optional: true)
+                    .AddEnvironmentVariables()
+                    .Build();
+
+                var connection = configuration.GetConnectionString("DefaultConnection");
+
+                if (string.IsNullOrWhiteSpace(connection))
+                {
+                    connection = "Host=localhost;Database=MiSalud;Username=postgres;Password=1234";
+                }
+
+                optionsBuilder.UseNpgsql(connection);
             }
         }
     }

--- a/Datos/ClinicaContext.cs
+++ b/Datos/ClinicaContext.cs
@@ -25,6 +25,7 @@ namespace MiSalud.Datos
         public DbSet<Servicio> Servicios { get; set; }
         public DbSet<TipoAlta> TiposAlta { get; set; }
         public DbSet<TipoHabitacion> TiposHabitacion { get; set; }
+        public DbSet<Auditoria> Auditoria { get; set; }
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {

--- a/Entidades/Auditoria.cs
+++ b/Entidades/Auditoria.cs
@@ -1,0 +1,29 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace MiSalud.Entidades
+{
+    [Table("auditoria")]
+    public class Auditoria
+    {
+        [Key]
+        [Column("auditoriaid")]
+        public int AuditoriaId { get; set; }
+
+        [Column("usuario")]
+        public string Usuario { get; set; }
+
+        [Column("tabla")]
+        public string Tabla { get; set; }
+
+        [Column("accion")]
+        public string Accion { get; set; }
+
+        [Column("detalle")]
+        public string Detalle { get; set; }
+
+        [Column("fecha")]
+        public DateTime Fecha { get; set; }
+    }
+}

--- a/Entidades/Consulta.cs
+++ b/Entidades/Consulta.cs
@@ -1,0 +1,47 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace MiSalud.Entidades
+{
+    [Table("consultas")]
+    public class Consulta
+    {
+        [Key]
+        [Column("consultaid")]
+        public int ConsultaId { get; set; }
+
+        [Required]
+        [Column("pacienteid")]
+        public int PacienteId { get; set; }
+
+        [Required]
+        [Column("personalid")]
+        public int PersonalId { get; set; }
+
+        [Required]
+        [Column("fechaconsulta")]
+        public DateTime FechaConsulta { get; set; }
+
+        [Column("motivocita")]
+        public string MotivoCita { get; set; }
+
+        [Column("diagnostico")]
+        public string Diagnostico { get; set; }
+
+        [Column("tratamiento")]
+        public string Tratamiento { get; set; }
+
+        [Column("observaciones")]
+        public string Observaciones { get; set; }
+
+        [Column("costo")]
+        public decimal? Costo { get; set; }
+
+        [Column("fecharegistro")]
+        public DateTime? FechaRegistro { get; set; }
+
+        [Column("estado")]
+        public bool Estado { get; set; }
+    }
+}

--- a/Entidades/ConsultaServicio.cs
+++ b/Entidades/ConsultaServicio.cs
@@ -1,0 +1,38 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace MiSalud.Entidades
+{
+    [Table("consultaservicios")]
+    public class ConsultaServicio
+    {
+        [Key]
+        [Column("consultaservicioid")]
+        public int ConsultaServicioId { get; set; }
+
+        [Required]
+        [Column("consultaid")]
+        public int ConsultaId { get; set; }
+
+        [Required]
+        [Column("servicioid")]
+        public int ServicioId { get; set; }
+
+        [Column("cantidad")]
+        public int? Cantidad { get; set; }
+
+        [Required]
+        [Column("fechaservicio")]
+        public DateTime FechaServicio { get; set; }
+
+        [Column("observaciones")]
+        public string Observaciones { get; set; }
+
+        [Column("fecharegistro")]
+        public DateTime? FechaRegistro { get; set; }
+
+        [Column("estado")]
+        public bool Estado { get; set; }
+    }
+}

--- a/Entidades/CuotaPlanPago.cs
+++ b/Entidades/CuotaPlanPago.cs
@@ -1,0 +1,42 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace MiSalud.Entidades
+{
+    [Table("cuotasplanpago")]
+    public class CuotaPlanPago
+    {
+        [Key]
+        [Column("cuotaid")]
+        public int CuotaId { get; set; }
+
+        [Required]
+        [Column("planpagoid")]
+        public int PlanPagoId { get; set; }
+
+        [Required]
+        [Column("numerocuota")]
+        public int NumeroCuota { get; set; }
+
+        [Required]
+        [Column("montocuota")]
+        public decimal MontoCuota { get; set; }
+
+        [Required]
+        [Column("fechavencimiento")]
+        public DateTime FechaVencimiento { get; set; }
+
+        [Column("fechapago")]
+        public DateTime? FechaPago { get; set; }
+
+        [Column("pagoid")]
+        public int? PagoId { get; set; }
+
+        [Column("estado")]
+        public string Estado { get; set; }
+
+        [Column("fecharegistro")]
+        public DateTime? FechaRegistro { get; set; }
+    }
+}

--- a/Entidades/Factura.cs
+++ b/Entidades/Factura.cs
@@ -1,0 +1,58 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace MiSalud.Entidades
+{
+    [Table("facturas")]
+    public class Factura
+    {
+        [Key]
+        [Column("facturaid")]
+        public int FacturaId { get; set; }
+
+        [Required]
+        [Column("pacienteid")]
+        public int PacienteId { get; set; }
+
+        [Required]
+        [Column("numerofactura")]
+        public string NumeroFactura { get; set; }
+
+        [Required]
+        [Column("fechaemision")]
+        public DateTime FechaEmision { get; set; }
+
+        [Column("fechavencimiento")]
+        public DateTime? FechaVencimiento { get; set; }
+
+        [Required]
+        [Column("subtotal")]
+        public decimal Subtotal { get; set; }
+
+        [Column("descuento")]
+        public decimal? Descuento { get; set; }
+
+        [Column("impuesto")]
+        public decimal? Impuesto { get; set; }
+
+        [Required]
+        [Column("total")]
+        public decimal Total { get; set; }
+
+        [Column("consultaid")]
+        public int? ConsultaId { get; set; }
+
+        [Column("hospitalizacionid")]
+        public int? HospitalizacionId { get; set; }
+
+        [Column("observaciones")]
+        public string Observaciones { get; set; }
+
+        [Column("fecharegistro")]
+        public DateTime? FechaRegistro { get; set; }
+
+        [Column("estado")]
+        public string Estado { get; set; }
+    }
+}

--- a/Entidades/FichaClinico.cs
+++ b/Entidades/FichaClinico.cs
@@ -1,0 +1,49 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace MiSalud.Entidades
+{
+    [Table("fichaclinico")]
+    public class FichaClinico
+    {
+        [Key]
+        [Column("fichaid")]
+        public int FichaId { get; set; }
+
+        [Required]
+        [Column("pacienteid")]
+        public int PacienteId { get; set; }
+
+        [Required]
+        [Column("personalid")]
+        public int PersonalId { get; set; }
+
+        [Column("fechaapertura")]
+        public DateTime? FechaApertura { get; set; }
+
+        [Column("motivoconsulta")]
+        public string MotivoConsulta { get; set; }
+
+        [Column("diagnosticoinicial")]
+        public string DiagnosticoInicial { get; set; }
+
+        [Column("antecedentespersonales")]
+        public string AntecedentesPersonales { get; set; }
+
+        [Column("antecedentesfamiliares")]
+        public string AntecedentesFamiliares { get; set; }
+
+        [Column("signosvitales")]
+        public string SignosVitales { get; set; }
+
+        [Column("tratamientosugerido")]
+        public string TratamientoSugerido { get; set; }
+
+        [Column("observaciones")]
+        public string Observaciones { get; set; }
+
+        [Column("estado")]
+        public string Estado { get; set; }
+    }
+}

--- a/Entidades/Habitacion.cs
+++ b/Entidades/Habitacion.cs
@@ -1,0 +1,34 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace MiSalud.Entidades
+{
+    [Table("habitaciones")]
+    public class Habitacion
+    {
+        [Key]
+        [Column("habitacionid")]
+        public int HabitacionId { get; set; }
+
+        [Required]
+        [Column("numero")]
+        public string Numero { get; set; }
+
+        [Required]
+        [Column("tipohabitacionid")]
+        public int TipoHabitacionId { get; set; }
+
+        [Column("capacidad")]
+        public int? Capacidad { get; set; }
+
+        [Column("disponible")]
+        public bool? Disponible { get; set; }
+
+        [Column("fechacreacion")]
+        public DateTime? FechaCreacion { get; set; }
+
+        [Column("estado")]
+        public bool Estado { get; set; }
+    }
+}

--- a/Entidades/Hospitalizacion.cs
+++ b/Entidades/Hospitalizacion.cs
@@ -1,0 +1,54 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace MiSalud.Entidades
+{
+    [Table("hospitalizaciones")]
+    public class Hospitalizacion
+    {
+        [Key]
+        [Column("hospitalizacionid")]
+        public int HospitalizacionId { get; set; }
+
+        [Required]
+        [Column("pacienteid")]
+        public int PacienteId { get; set; }
+
+        [Required]
+        [Column("habitacionid")]
+        public int HabitacionId { get; set; }
+
+        [Required]
+        [Column("personalid")]
+        public int PersonalId { get; set; }
+
+        [Required]
+        [Column("fechaingreso")]
+        public DateTime FechaIngreso { get; set; }
+
+        [Column("fechaalta")]
+        public DateTime? FechaAlta { get; set; }
+
+        [Column("tipoaltaid")]
+        public int? TipoAltaId { get; set; }
+
+        [Column("diagnostico")]
+        public string Diagnostico { get; set; }
+
+        [Column("tratamientoaplicado")]
+        public string TratamientoAplicado { get; set; }
+
+        [Column("motivohospitalizacion")]
+        public string MotivoHospitalizacion { get; set; }
+
+        [Column("observaciones")]
+        public string Observaciones { get; set; }
+
+        [Column("fecharegistro")]
+        public DateTime? FechaRegistro { get; set; }
+
+        [Column("estado")]
+        public bool Estado { get; set; }
+    }
+}

--- a/Entidades/HospitalizacionServicio.cs
+++ b/Entidades/HospitalizacionServicio.cs
@@ -1,0 +1,41 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace MiSalud.Entidades
+{
+    [Table("hospitalizacionservicios")]
+    public class HospitalizacionServicio
+    {
+        [Key]
+        [Column("hospitalizacionservicioid")]
+        public int HospitalizacionServicioId { get; set; }
+
+        [Required]
+        [Column("hospitalizacionid")]
+        public int HospitalizacionId { get; set; }
+
+        [Required]
+        [Column("servicioid")]
+        public int ServicioId { get; set; }
+
+        [Column("cantidad")]
+        public int? Cantidad { get; set; }
+
+        [Required]
+        [Column("fechaservicio")]
+        public DateTime FechaServicio { get; set; }
+
+        [Column("observaciones")]
+        public string Observaciones { get; set; }
+
+        [Column("personalsolicitanteid")]
+        public int? PersonalSolicitanteId { get; set; }
+
+        [Column("fecharegistro")]
+        public DateTime? FechaRegistro { get; set; }
+
+        [Column("estado")]
+        public bool Estado { get; set; }
+    }
+}

--- a/Entidades/HuellaDactilar.cs
+++ b/Entidades/HuellaDactilar.cs
@@ -1,0 +1,31 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace MiSalud.Entidades
+{
+    [Table("huellasdactilares")]
+    public class HuellaDactilar
+    {
+        [Key]
+        [Column("huellaid")]
+        public int HuellaId { get; set; }
+
+        [Required]
+        [Column("pacienteid")]
+        public int PacienteId { get; set; }
+
+        [Column("mano")]
+        public string Mano { get; set; }
+
+        [Column("dedo")]
+        public string Dedo { get; set; }
+
+        [Required]
+        [Column("template")]
+        public byte[] Template { get; set; }
+
+        [Column("fecharegistro")]
+        public DateTime? FechaRegistro { get; set; }
+    }
+}

--- a/Entidades/MetodoPago.cs
+++ b/Entidades/MetodoPago.cs
@@ -1,0 +1,30 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace MiSalud.Entidades
+{
+    [Table("metodospago")]
+    public class MetodoPago
+    {
+        [Key]
+        [Column("metodopagoid")]
+        public int MetodoPagoId { get; set; }
+
+        [Required]
+        [Column("nombre")]
+        public string Nombre { get; set; }
+
+        [Column("descripcion")]
+        public string Descripcion { get; set; }
+
+        [Column("requiereverificacion")]
+        public bool? RequiereVerificacion { get; set; }
+
+        [Column("fechacreacion")]
+        public DateTime? FechaCreacion { get; set; }
+
+        [Column("estado")]
+        public bool Estado { get; set; }
+    }
+}

--- a/Entidades/Paciente.cs
+++ b/Entidades/Paciente.cs
@@ -1,0 +1,62 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace MiSalud.Entidades
+{
+    [Table("pacientes")]
+    public class Paciente
+    {
+        [Key]
+        [Column("pacienteid")]
+        public int PacienteId { get; set; }
+
+        [Required]
+        [Column("nombres")]
+        public string Nombres { get; set; }
+
+        [Required]
+        [Column("apellidos")]
+        public string Apellidos { get; set; }
+
+        [Required]
+        [Column("numerodocumento")]
+        public string NumeroDocumento { get; set; }
+
+        [Column("tipodocumento")]
+        public string TipoDocumento { get; set; }
+
+        [Column("fechanacimiento")]
+        public DateTime? FechaNacimiento { get; set; }
+
+        [Column("edad")]
+        public int? Edad { get; set; }
+
+        [Column("genero")]
+        public string Genero { get; set; }
+
+        [Column("direccion")]
+        public string Direccion { get; set; }
+
+        [Column("telefono")]
+        public string Telefono { get; set; }
+
+        [Column("email")]
+        public string Email { get; set; }
+
+        [Column("gruposanguineo")]
+        public string GrupoSanguineo { get; set; }
+
+        [Column("alergias")]
+        public string Alergias { get; set; }
+
+        [Column("observaciones")]
+        public string Observaciones { get; set; }
+
+        [Column("fecharegistro")]
+        public DateTime? FechaRegistro { get; set; }
+
+        [Column("estado")]
+        public bool Estado { get; set; }
+    }
+}

--- a/Entidades/Pago.cs
+++ b/Entidades/Pago.cs
@@ -1,0 +1,42 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace MiSalud.Entidades
+{
+    [Table("pagos")]
+    public class Pago
+    {
+        [Key]
+        [Column("pagoid")]
+        public int PagoId { get; set; }
+
+        [Required]
+        [Column("facturaid")]
+        public int FacturaId { get; set; }
+
+        [Required]
+        [Column("metodopagoid")]
+        public int MetodoPagoId { get; set; }
+
+        [Required]
+        [Column("monto")]
+        public decimal Monto { get; set; }
+
+        [Required]
+        [Column("fechapago")]
+        public DateTime FechaPago { get; set; }
+
+        [Column("numeroreferencia")]
+        public string NumeroReferencia { get; set; }
+
+        [Column("observaciones")]
+        public string Observaciones { get; set; }
+
+        [Column("fecharegistro")]
+        public DateTime? FechaRegistro { get; set; }
+
+        [Column("estado")]
+        public bool Estado { get; set; }
+    }
+}

--- a/Entidades/PlanPago.cs
+++ b/Entidades/PlanPago.cs
@@ -1,0 +1,46 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace MiSalud.Entidades
+{
+    [Table("planespago")]
+    public class PlanPago
+    {
+        [Key]
+        [Column("planpagoid")]
+        public int PlanPagoId { get; set; }
+
+        [Required]
+        [Column("facturaid")]
+        public int FacturaId { get; set; }
+
+        [Required]
+        [Column("fechainicio")]
+        public DateTime FechaInicio { get; set; }
+
+        [Required]
+        [Column("fechafin")]
+        public DateTime FechaFin { get; set; }
+
+        [Required]
+        [Column("numerocuotas")]
+        public int NumeroCuotas { get; set; }
+
+        [Required]
+        [Column("montototal")]
+        public decimal MontoTotal { get; set; }
+
+        [Column("interes")]
+        public decimal? Interes { get; set; }
+
+        [Column("observaciones")]
+        public string Observaciones { get; set; }
+
+        [Column("fecharegistro")]
+        public DateTime? FechaRegistro { get; set; }
+
+        [Column("estado")]
+        public string Estado { get; set; }
+    }
+}

--- a/Entidades/Servicio.cs
+++ b/Entidades/Servicio.cs
@@ -1,0 +1,37 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace MiSalud.Entidades
+{
+    [Table("servicios")]
+    public class Servicio
+    {
+        [Key]
+        [Column("servicioid")]
+        public int ServicioId { get; set; }
+
+        [Required]
+        [Column("nombre")]
+        public string Nombre { get; set; }
+
+        [Column("descripcion")]
+        public string Descripcion { get; set; }
+
+        [Required]
+        [Column("costo")]
+        public decimal Costo { get; set; }
+
+        [Column("costopacienteasegurado")]
+        public decimal? CostoPacienteAsegurado { get; set; }
+
+        [Column("requiereprescripcion")]
+        public bool? RequierePrescripcion { get; set; }
+
+        [Column("fechacreacion")]
+        public DateTime? FechaCreacion { get; set; }
+
+        [Column("estado")]
+        public bool Estado { get; set; }
+    }
+}

--- a/Entidades/TipoAlta.cs
+++ b/Entidades/TipoAlta.cs
@@ -1,0 +1,27 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace MiSalud.Entidades
+{
+    [Table("tiposalta")]
+    public class TipoAlta
+    {
+        [Key]
+        [Column("tipoaltaid")]
+        public int TipoAltaId { get; set; }
+
+        [Required]
+        [Column("nombre")]
+        public string Nombre { get; set; }
+
+        [Column("descripcion")]
+        public string Descripcion { get; set; }
+
+        [Column("fechacreacion")]
+        public DateTime? FechaCreacion { get; set; }
+
+        [Column("estado")]
+        public bool Estado { get; set; }
+    }
+}

--- a/Entidades/TipoHabitacion.cs
+++ b/Entidades/TipoHabitacion.cs
@@ -1,0 +1,31 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace MiSalud.Entidades
+{
+    [Table("tiposhabitacion")]
+    public class TipoHabitacion
+    {
+        [Key]
+        [Column("tipohabitacionid")]
+        public int TipoHabitacionId { get; set; }
+
+        [Required]
+        [Column("nombre")]
+        public string Nombre { get; set; }
+
+        [Column("descripcion")]
+        public string Descripcion { get; set; }
+
+        [Required]
+        [Column("costodiario")]
+        public decimal CostoDiario { get; set; }
+
+        [Column("fechacreacion")]
+        public DateTime? FechaCreacion { get; set; }
+
+        [Column("estado")]
+        public bool Estado { get; set; }
+    }
+}

--- a/Login/LoginForm.cs
+++ b/Login/LoginForm.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Windows.Forms;
 using MiSalud.Datos; // Asegúrate de que este namespace exista y tenga ClinicaContext
 using Login;         // Aquí está SelectorRoles
+using MiSalud.Utilidades;
 
 namespace Login
 {
@@ -31,9 +32,11 @@ namespace Login
             string user = txtUsuario.Text.Trim();
             string pass = txtContrasena.Text.Trim();
 
+            string hash = Seguridad.HashPassword(pass);
+
             // Consulta LINQ para validar credenciales
             var login = _context.Personal
-                .FirstOrDefault(p => p.Usuario == user && p.Contrasena == pass && p.Estado == true);
+                .FirstOrDefault(p => p.Usuario == user && p.Contrasena == hash && p.Estado == true);
 
             if (login != null)
             {

--- a/Login/SelectorRoles.cs
+++ b/Login/SelectorRoles.cs
@@ -9,9 +9,12 @@ namespace Login
 {
     public class SelectorRoles
     {
+        public static string UsuarioActual { get; private set; }
+
         // Método estático que abre el formulario correspondiente según el rol
         public static void AbrirMenuPorRol(string rol, string usuario)
         {
+            UsuarioActual = usuario;
             Form formRol = null;
 
             switch (rol)

--- a/MiSalud.csproj
+++ b/MiSalud.csproj
@@ -15,6 +15,8 @@
     </PackageReference>
     <PackageReference Include="Npgsql" Version="9.0.3" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/README.md
+++ b/README.md
@@ -29,3 +29,15 @@ Use the .NET SDK (8.0 or later) to build the project:
 
 Execute the compiled application or run through `dotnet run`. Ensure PostgreSQL is reachable using the configured connection string.
 
+## Modules
+
+Administrators have access to several modules:
+
+- Gestión de Personal
+- Especialidades médicas
+- Servicios médicos
+- Consultas y hospitalizaciones
+- Facturación y planes de pago
+- Fichas clínicas y reportes
+- Configuración y **Auditoría** para revisar acciones registradas
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# MiSalud
+
+Windows Forms application for clinical management. The application uses Entity Framework Core and PostgreSQL.
+
+## Configuration
+
+Database settings are stored in `appsettings.json` located in the project root. Modify the connection string under `ConnectionStrings:DefaultConnection` to match your environment.
+
+Example:
+```json
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "Host=localhost;Database=MiSalud;Username=postgres;Password=1234"
+  }
+}
+```
+
+Alternatively, you can specify the connection string via the `DefaultConnection` environment variable. The application will fall back to the default in `appsettings.json` if no environment variable is set.
+
+## Building
+
+Use the .NET SDK (8.0 or later) to build the project:
+
+```bash
+ dotnet build -c Release
+```
+
+## Running
+
+Execute the compiled application or run through `dotnet run`. Ensure PostgreSQL is reachable using the configured connection string.
+

--- a/Roles/Admin/Auditoria/FormAuditoria.cs
+++ b/Roles/Admin/Auditoria/FormAuditoria.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Linq;
+using System.Windows.Forms;
+using MiSalud.Datos;
+
+namespace MiSalud.Roles.Admin.Auditoria
+{
+    public partial class FormAuditoria : Form
+    {
+        private DataGridView dgv;
+        private DateTimePicker dtpDesde;
+        private DateTimePicker dtpHasta;
+        private TextBox txtUsuario;
+        private Button btnFiltrar;
+
+        public FormAuditoria()
+        {
+            InitializeComponent();
+        }
+
+        private void InitializeComponent()
+        {
+            this.Load += FormAuditoria_Load;
+        }
+
+        private void FormAuditoria_Load(object sender, EventArgs e)
+        {
+            this.BackColor = System.Drawing.Color.White;
+            this.Dock = DockStyle.Fill;
+            InicializarControles();
+            CargarAuditoria();
+        }
+
+        private void InicializarControles()
+        {
+            dgv = new DataGridView
+            {
+                Dock = DockStyle.Bottom,
+                Height = 300,
+                ReadOnly = true,
+                AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.Fill
+            };
+
+            var lblDesde = new Label { Text = "Desde", Top = 60, Left = 20 };
+            dtpDesde = new DateTimePicker { Top = 80, Left = 20, Width = 200 };
+            var lblHasta = new Label { Text = "Hasta", Top = 110, Left = 20 };
+            dtpHasta = new DateTimePicker { Top = 130, Left = 20, Width = 200 };
+            var lblUsuario = new Label { Text = "Usuario", Top = 160, Left = 20 };
+            txtUsuario = new TextBox { Top = 180, Left = 20, Width = 200 };
+
+            btnFiltrar = new Button { Text = "Filtrar", Top = 210, Left = 20 };
+            btnFiltrar.Click += BtnFiltrar_Click;
+
+            Controls.AddRange(new Control[]
+            {
+                lblDesde, dtpDesde, lblHasta, dtpHasta,
+                lblUsuario, txtUsuario, btnFiltrar, dgv
+            });
+        }
+
+        private void BtnFiltrar_Click(object sender, EventArgs e)
+        {
+            CargarAuditoria();
+        }
+
+        private void CargarAuditoria()
+        {
+            using var ctx = new ClinicaContext();
+            var desde = dtpDesde.Value.Date;
+            var hasta = dtpHasta.Value.Date.AddDays(1);
+            var query = ctx.Auditoria.AsQueryable();
+            query = query.Where(a => a.Fecha >= desde && a.Fecha < hasta);
+            if (!string.IsNullOrWhiteSpace(txtUsuario.Text))
+            {
+                query = query.Where(a => a.Usuario.Contains(txtUsuario.Text));
+            }
+
+            var lista = query
+                .OrderByDescending(a => a.Fecha)
+                .Select(a => new { a.AuditoriaId, a.Usuario, a.Tabla, a.Accion, a.Detalle, a.Fecha })
+                .ToList();
+
+            dgv.DataSource = lista;
+        }
+    }
+}

--- a/Roles/Admin/Configuracion/FormConfiguracionSistema.cs
+++ b/Roles/Admin/Configuracion/FormConfiguracionSistema.cs
@@ -1,10 +1,13 @@
-﻿using System;
+using System;
 using System.Windows.Forms;
+using Microsoft.EntityFrameworkCore;
 
 namespace MiSalud.Roles.Admin.Configuracion
 {
     public partial class FormConfiguracionSistema : Form
     {
+        private Button btnBackup;
+
         public FormConfiguracionSistema()
         {
             InitializeComponent();
@@ -14,7 +17,36 @@ namespace MiSalud.Roles.Admin.Configuracion
         {
             this.BackColor = System.Drawing.Color.White;
             this.Dock = DockStyle.Fill;
+            btnBackup = new Button { Text = "Realizar Backup", Top = 60, Left = 20 };
+            btnBackup.Click += BtnBackup_Click;
+            Controls.Add(btnBackup);
+        }
+
+        private void BtnBackup_Click(object sender, EventArgs e)
+        {
+            using (var ctx = new Datos.ClinicaContext())
+            {
+                var connection = ctx.Database.GetConnectionString();
+                try
+                {
+                    string file = $"backup_{DateTime.Now:yyyyMMdd_HHmmss}.sql";
+                    var psi = new System.Diagnostics.ProcessStartInfo
+                    {
+                        FileName = "pg_dump",
+                        Arguments = $"--file \"{file}\" \"{connection}\"",
+                        RedirectStandardOutput = true,
+                        RedirectStandardError = true,
+                        UseShellExecute = false
+                    };
+                    var process = System.Diagnostics.Process.Start(psi);
+                    process.WaitForExit();
+                    MessageBox.Show($"Backup generado: {file}");
+                }
+                catch (Exception ex)
+                {
+                    MessageBox.Show($"Error al generar backup: {ex.Message}");
+                }
+            }
         }
     }
 }
-

--- a/Roles/Admin/Consultas/FormVerConsultas.cs
+++ b/Roles/Admin/Consultas/FormVerConsultas.cs
@@ -1,10 +1,19 @@
-﻿using System;
+using System;
+using System.Linq;
 using System.Windows.Forms;
+using MiSalud.Datos;
 
 namespace MiSalud.Roles.Admin.Consultas
 {
     public partial class FormVerConsultas : Form
     {
+        private DataGridView dgv;
+        private DateTimePicker dtpDesde;
+        private DateTimePicker dtpHasta;
+        private ComboBox cbMedico;
+        private ComboBox cbPaciente;
+        private Button btnFiltrar;
+
         public FormVerConsultas()
         {
             InitializeComponent();
@@ -14,7 +23,97 @@ namespace MiSalud.Roles.Admin.Consultas
         {
             this.BackColor = System.Drawing.Color.White;
             this.Dock = DockStyle.Fill;
+            InicializarControles();
+            CargarListas();
+            CargarConsultas();
+        }
+
+        private void InicializarControles()
+        {
+            dgv = new DataGridView
+            {
+                Dock = DockStyle.Bottom,
+                Height = 250,
+                ReadOnly = true,
+                AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.Fill
+            };
+
+            var lblDesde = new Label { Text = "Desde", Top = 60, Left = 20 };
+            dtpDesde = new DateTimePicker { Top = 80, Left = 20, Width = 200 };
+            var lblHasta = new Label { Text = "Hasta", Top = 110, Left = 20 };
+            dtpHasta = new DateTimePicker { Top = 130, Left = 20, Width = 200 };
+            var lblMedico = new Label { Text = "Médico", Top = 160, Left = 20 };
+            cbMedico = new ComboBox { Top = 180, Left = 20, Width = 200, DropDownStyle = ComboBoxStyle.DropDownList };
+            var lblPaciente = new Label { Text = "Paciente", Top = 210, Left = 20 };
+            cbPaciente = new ComboBox { Top = 230, Left = 20, Width = 200, DropDownStyle = ComboBoxStyle.DropDownList };
+
+            btnFiltrar = new Button { Text = "Filtrar", Top = 260, Left = 20 };
+            btnFiltrar.Click += BtnFiltrar_Click;
+
+            Controls.AddRange(new Control[]
+            {
+                lblDesde, dtpDesde, lblHasta, dtpHasta,
+                lblMedico, cbMedico, lblPaciente, cbPaciente,
+                btnFiltrar, dgv
+            });
+        }
+
+        private void CargarListas()
+        {
+            using (var ctx = new ClinicaContext())
+            {
+                var medicos = ctx.Personal
+                    .Where(p => p.Rol == "Doctor" && p.Estado)
+                    .Select(p => new { p.PersonalId, Nombre = p.Nombres + " " + p.Apellidos })
+                    .ToList();
+                medicos.Insert(0, new { PersonalId = 0, Nombre = "Todos" });
+                cbMedico.DataSource = medicos;
+                cbMedico.DisplayMember = "Nombre";
+                cbMedico.ValueMember = "PersonalId";
+
+                var pacientes = ctx.Pacientes
+                    .Select(p => new { p.PacienteId, Nombre = p.Nombres + " " + p.Apellidos })
+                    .ToList();
+                pacientes.Insert(0, new { PacienteId = 0, Nombre = "Todos" });
+                cbPaciente.DataSource = pacientes;
+                cbPaciente.DisplayMember = "Nombre";
+                cbPaciente.ValueMember = "PacienteId";
+            }
+        }
+
+        private void BtnFiltrar_Click(object sender, EventArgs e)
+        {
+            CargarConsultas();
+        }
+
+        private void CargarConsultas()
+        {
+            using (var ctx = new ClinicaContext())
+            {
+                var desde = dtpDesde.Value.Date;
+                var hasta = dtpHasta.Value.Date.AddDays(1);
+                var query = ctx.Consultas.AsQueryable();
+
+                query = query.Where(c => c.FechaConsulta >= desde && c.FechaConsulta < hasta);
+
+                int idMedico = (int)cbMedico.SelectedValue;
+                if (idMedico != 0)
+                {
+                    query = query.Where(c => c.PersonalId == idMedico);
+                }
+
+                int idPaciente = (int)cbPaciente.SelectedValue;
+                if (idPaciente != 0)
+                {
+                    query = query.Where(c => c.PacienteId == idPaciente);
+                }
+
+                var lista = query
+                    .Select(c => new { c.ConsultaId, c.PacienteId, c.PersonalId, c.FechaConsulta, c.Estado })
+                    .ToList();
+
+                dgv.DataSource = lista;
+            }
         }
     }
 }
-

--- a/Roles/Admin/Especialidades/FormGestionEspecialidades.cs
+++ b/Roles/Admin/Especialidades/FormGestionEspecialidades.cs
@@ -1,10 +1,22 @@
-﻿using System;
+using System;
+using System.Linq;
 using System.Windows.Forms;
+using MiSalud.Datos;
+using Entidades = MiSalud.Entidades;
 
 namespace MiSalud.Roles.Admin.Especialidades
 {
     public partial class FormGestionEspecialidades : Form
     {
+        private DataGridView dgv;
+        private TextBox txtNombre;
+        private TextBox txtDescripcion;
+        private CheckBox chkEstado;
+        private Button btnGuardar;
+        private Button btnEliminar;
+        private Button btnLimpiar;
+        private int? idSeleccionado = null;
+
         public FormGestionEspecialidades()
         {
             InitializeComponent();
@@ -14,7 +26,138 @@ namespace MiSalud.Roles.Admin.Especialidades
         {
             this.BackColor = System.Drawing.Color.White;
             this.Dock = DockStyle.Fill;
+            InicializarControles();
+            CargarEspecialidades();
+        }
+
+        private void InicializarControles()
+        {
+            dgv = new DataGridView
+            {
+                Dock = DockStyle.Bottom,
+                Height = 250,
+                ReadOnly = true,
+                AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.Fill
+            };
+            dgv.CellDoubleClick += Dgv_CellDoubleClick;
+
+            var lblNombre = new Label { Text = "Nombre", Top = 60, Left = 20 };
+            txtNombre = new TextBox { Top = 80, Left = 20, Width = 200 };
+            var lblDescripcion = new Label { Text = "Descripción", Top = 110, Left = 20 };
+            txtDescripcion = new TextBox { Top = 130, Left = 20, Width = 300 };
+            chkEstado = new CheckBox { Text = "Activo", Top = 160, Left = 20 };
+
+            btnGuardar = new Button { Text = "Guardar", Top = 190, Left = 20 };
+            btnGuardar.Click += BtnGuardar_Click;
+            btnEliminar = new Button { Text = "Eliminar", Top = 190, Left = 120 };
+            btnEliminar.Click += BtnEliminar_Click;
+            btnLimpiar = new Button { Text = "Limpiar", Top = 190, Left = 220 };
+            btnLimpiar.Click += BtnLimpiar_Click;
+
+            Controls.AddRange(new Control[]
+            {
+                lblNombre, txtNombre, lblDescripcion, txtDescripcion, chkEstado,
+                btnGuardar, btnEliminar, btnLimpiar, dgv
+            });
+        }
+
+        private void BtnGuardar_Click(object sender, EventArgs e)
+        {
+            if (string.IsNullOrWhiteSpace(txtNombre.Text))
+            {
+                MessageBox.Show("El nombre es obligatorio");
+                return;
+            }
+
+            using (var ctx = new ClinicaContext())
+            {
+                if (idSeleccionado == null)
+                {
+                    var esp = new Entidades.Especialidad
+                    {
+                        NombreEspecialidad = txtNombre.Text,
+                        Descripcion = txtDescripcion.Text,
+                        Estado = chkEstado.Checked,
+                        FechaCreacion = DateTime.Now
+                    };
+                    ctx.Especialidades.Add(esp);
+                    ctx.SaveChanges();
+                }
+                else
+                {
+                    var esp = ctx.Especialidades.FirstOrDefault(e => e.EspecialidadId == idSeleccionado);
+                    if (esp != null)
+                    {
+                        esp.NombreEspecialidad = txtNombre.Text;
+                        esp.Descripcion = txtDescripcion.Text;
+                        esp.Estado = chkEstado.Checked;
+                        ctx.SaveChanges();
+                    }
+                }
+            }
+
+            Limpiar();
+            CargarEspecialidades();
+        }
+
+        private void BtnEliminar_Click(object sender, EventArgs e)
+        {
+            if (idSeleccionado == null)
+            {
+                MessageBox.Show("Selecciona un registro de la lista");
+                return;
+            }
+
+            using (var ctx = new ClinicaContext())
+            {
+                var esp = ctx.Especialidades.FirstOrDefault(e => e.EspecialidadId == idSeleccionado);
+                if (esp != null)
+                {
+                    ctx.Especialidades.Remove(esp);
+                    ctx.SaveChanges();
+                }
+            }
+
+            Limpiar();
+            CargarEspecialidades();
+        }
+
+        private void BtnLimpiar_Click(object sender, EventArgs e)
+        {
+            Limpiar();
+        }
+
+        private void Dgv_CellDoubleClick(object sender, DataGridViewCellEventArgs e)
+        {
+            if (e.RowIndex >= 0)
+            {
+                var fila = dgv.Rows[e.RowIndex];
+                idSeleccionado = Convert.ToInt32(fila.Cells["EspecialidadId"].Value);
+                txtNombre.Text = fila.Cells["NombreEspecialidad"].Value?.ToString();
+                txtDescripcion.Text = fila.Cells["Descripcion"].Value?.ToString();
+                chkEstado.Checked = Convert.ToBoolean(fila.Cells["Estado"].Value);
+                btnGuardar.Text = "Actualizar";
+            }
+        }
+
+        private void CargarEspecialidades()
+        {
+            using (var ctx = new ClinicaContext())
+            {
+                var lista = ctx.Especialidades
+                    .Select(e => new { e.EspecialidadId, e.NombreEspecialidad, e.Descripcion, e.Estado })
+                    .ToList();
+                dgv.DataSource = lista;
+            }
+        }
+
+        private void Limpiar()
+        {
+            txtNombre.Text = string.Empty;
+            txtDescripcion.Text = string.Empty;
+            chkEstado.Checked = false;
+            btnGuardar.Text = "Guardar";
+            idSeleccionado = null;
         }
     }
 }
-

--- a/Roles/Admin/Facturacion/FormVerFacturas.cs
+++ b/Roles/Admin/Facturacion/FormVerFacturas.cs
@@ -1,10 +1,16 @@
-﻿using System;
+using System;
+using System.Linq;
 using System.Windows.Forms;
+using MiSalud.Datos;
 
 namespace MiSalud.Roles.Admin.Facturacion
 {
     public partial class FormVerFacturas : Form
     {
+        private DataGridView dgv;
+        private ComboBox cbEstado;
+        private Button btnAnular;
+
         public FormVerFacturas()
         {
             InitializeComponent();
@@ -14,7 +20,65 @@ namespace MiSalud.Roles.Admin.Facturacion
         {
             this.BackColor = System.Drawing.Color.White;
             this.Dock = DockStyle.Fill;
+            InicializarControles();
+            CargarFacturas();
+        }
+
+        private void InicializarControles()
+        {
+            dgv = new DataGridView
+            {
+                Dock = DockStyle.Bottom,
+                Height = 250,
+                ReadOnly = true,
+                AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.Fill
+            };
+
+            var lblEstado = new Label { Text = "Estado", Top = 60, Left = 20 };
+            cbEstado = new ComboBox { Top = 80, Left = 20, Width = 200, DropDownStyle = ComboBoxStyle.DropDownList };
+            cbEstado.Items.AddRange(new object[] { "Todos", "Pendiente", "Pagado", "Anulado" });
+            cbEstado.SelectedIndex = 0;
+
+            btnAnular = new Button { Text = "Anular Seleccionada", Top = 110, Left = 20 };
+            btnAnular.Click += BtnAnular_Click;
+
+            Controls.AddRange(new Control[] { lblEstado, cbEstado, btnAnular, dgv });
+        }
+
+        private void BtnAnular_Click(object sender, EventArgs e)
+        {
+            if (dgv.CurrentRow == null)
+                return;
+
+            int id = Convert.ToInt32(dgv.CurrentRow.Cells["FacturaId"].Value);
+            using (var ctx = new ClinicaContext())
+            {
+                var fac = ctx.Facturas.FirstOrDefault(f => f.FacturaId == id);
+                if (fac != null && fac.Estado != "Anulado")
+                {
+                    fac.Estado = "Anulado";
+                    ctx.SaveChanges();
+                    CargarFacturas();
+                }
+            }
+        }
+
+        private void CargarFacturas()
+        {
+            using (var ctx = new ClinicaContext())
+            {
+                var query = ctx.Facturas.AsQueryable();
+                if (cbEstado.SelectedIndex > 0)
+                {
+                    string estado = cbEstado.SelectedItem.ToString();
+                    query = query.Where(f => f.Estado == estado);
+                }
+
+                var lista = query
+                    .Select(f => new { f.FacturaId, f.NumeroFactura, f.PacienteId, f.Total, f.Estado })
+                    .ToList();
+                dgv.DataSource = lista;
+            }
         }
     }
 }
-

--- a/Roles/Admin/FichasClinicas/FormVerFichasClinicas.cs
+++ b/Roles/Admin/FichasClinicas/FormVerFichasClinicas.cs
@@ -1,10 +1,14 @@
-﻿using System;
+using System;
+using System.Linq;
 using System.Windows.Forms;
+using MiSalud.Datos;
 
 namespace MiSalud.Roles.Admin.FichasClinicas
 {
     public partial class FormVerFichasClinicas : Form
     {
+        private DataGridView dgv;
+
         public FormVerFichasClinicas()
         {
             InitializeComponent();
@@ -14,7 +18,30 @@ namespace MiSalud.Roles.Admin.FichasClinicas
         {
             this.BackColor = System.Drawing.Color.White;
             this.Dock = DockStyle.Fill;
+            InicializarControles();
+            CargarFichas();
+        }
+
+        private void InicializarControles()
+        {
+            dgv = new DataGridView
+            {
+                Dock = DockStyle.Fill,
+                ReadOnly = true,
+                AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.Fill
+            };
+            Controls.Add(dgv);
+        }
+
+        private void CargarFichas()
+        {
+            using (var ctx = new ClinicaContext())
+            {
+                var lista = ctx.FichasClinico
+                    .Select(f => new { f.FichaId, f.PacienteId, f.PersonalId, f.FechaApertura, f.Estado })
+                    .ToList();
+                dgv.DataSource = lista;
+            }
         }
     }
 }
-

--- a/Roles/Admin/FormAdmin.Designer.cs
+++ b/Roles/Admin/FormAdmin.Designer.cs
@@ -51,17 +51,17 @@ namespace MiSalud.Roles.Admin
             // 
             string[] nombres = {
                 "btnPersonal", "btnUsuarios", "btnEspecialidades", "btnServicios", "btnConsultas", "btnHospitalizaciones",
-                "btnFacturacion", "btnPlanesPago", "btnFichasClinicas", "btnReportes", "btnConfiguracion", "btnCerrarSesion"
+                "btnFacturacion", "btnPlanesPago", "btnFichasClinicas", "btnReportes", "btnAuditoria", "btnConfiguracion", "btnCerrarSesion"
             };
 
             string[] textos = {
                 "Gestión Personal", "Usuarios", "Especialidades", "Servicios", "Consultas", "Hospitalizaciones",
-                "Facturación", "Planes de Pago", "Fichas Clínicas", "Reportes", "Configuración", "Cerrar Sesión"
+                "Facturación", "Planes de Pago", "Fichas Clínicas", "Reportes", "Auditoría", "Configuración", "Cerrar Sesión"
             };
 
             EventHandler[] eventos = {
                 btnPersonal_Click, btnUsuarios_Click, btnEspecialidades_Click, btnServicios_Click, btnConsultas_Click, btnHospitalizaciones_Click,
-                btnFacturacion_Click, btnPlanesPago_Click, btnFichasClinicas_Click, btnReportes_Click, btnConfiguracion_Click, btnCerrarSesion_Click
+                btnFacturacion_Click, btnPlanesPago_Click, btnFichasClinicas_Click, btnReportes_Click, btnAuditoria_Click, btnConfiguracion_Click, btnCerrarSesion_Click
             };
 
             System.Windows.Forms.Button[] referencias = new System.Windows.Forms.Button[nombres.Length];

--- a/Roles/Admin/FormAdmin.Designer.cs
+++ b/Roles/Admin/FormAdmin.Designer.cs
@@ -50,17 +50,17 @@ namespace MiSalud.Roles.Admin
             // Botones con estilo clínico moderno
             // 
             string[] nombres = {
-                "btnPersonal", "btnEspecialidades", "btnServicios", "btnConsultas", "btnHospitalizaciones",
+                "btnPersonal", "btnUsuarios", "btnEspecialidades", "btnServicios", "btnConsultas", "btnHospitalizaciones",
                 "btnFacturacion", "btnPlanesPago", "btnFichasClinicas", "btnReportes", "btnConfiguracion", "btnCerrarSesion"
             };
 
             string[] textos = {
-                "Gestión Personal", "Especialidades", "Servicios", "Consultas", "Hospitalizaciones",
+                "Gestión Personal", "Usuarios", "Especialidades", "Servicios", "Consultas", "Hospitalizaciones",
                 "Facturación", "Planes de Pago", "Fichas Clínicas", "Reportes", "Configuración", "Cerrar Sesión"
             };
 
             EventHandler[] eventos = {
-                btnPersonal_Click, btnEspecialidades_Click, btnServicios_Click, btnConsultas_Click, btnHospitalizaciones_Click,
+                btnPersonal_Click, btnUsuarios_Click, btnEspecialidades_Click, btnServicios_Click, btnConsultas_Click, btnHospitalizaciones_Click,
                 btnFacturacion_Click, btnPlanesPago_Click, btnFichasClinicas_Click, btnReportes_Click, btnConfiguracion_Click, btnCerrarSesion_Click
             };
 

--- a/Roles/Admin/FormAdmin.cs
+++ b/Roles/Admin/FormAdmin.cs
@@ -86,6 +86,11 @@ namespace MiSalud.Roles.Admin
             AbrirFormulario(new Reportes.FormReportes());
         }
 
+        private void btnAuditoria_Click(object sender, EventArgs e)
+        {
+            AbrirFormulario(new Auditoria.FormAuditoria());
+        }
+
         private void btnConfiguracion_Click(object sender, EventArgs e)
         {
             AbrirFormulario(new Configuracion.FormConfiguracionSistema());

--- a/Roles/Admin/FormAdmin.cs
+++ b/Roles/Admin/FormAdmin.cs
@@ -41,6 +41,11 @@ namespace MiSalud.Roles.Admin
             AbrirFormulario(new MiSalud.Roles.Admin.Personal.FormGestionPersonal());
         }
 
+        private void btnUsuarios_Click(object sender, EventArgs e)
+        {
+            AbrirFormulario(new Usuarios.FormGestionUsuarios());
+        }
+
         private void btnEspecialidades_Click(object sender, EventArgs e)
         {
             AbrirFormulario(new Especialidades.FormGestionEspecialidades());

--- a/Roles/Admin/Hospitalizaciones/FormVerHospitalizaciones.cs
+++ b/Roles/Admin/Hospitalizaciones/FormVerHospitalizaciones.cs
@@ -1,10 +1,14 @@
-﻿using System;
+using System;
+using System.Linq;
 using System.Windows.Forms;
+using MiSalud.Datos;
 
 namespace MiSalud.Roles.Admin.Hospitalizaciones
 {
     public partial class FormVerHospitalizaciones : Form
     {
+        private DataGridView dgv;
+
         public FormVerHospitalizaciones()
         {
             InitializeComponent();
@@ -14,7 +18,30 @@ namespace MiSalud.Roles.Admin.Hospitalizaciones
         {
             this.BackColor = System.Drawing.Color.White;
             this.Dock = DockStyle.Fill;
+            InicializarControles();
+            CargarHospitalizaciones();
+        }
+
+        private void InicializarControles()
+        {
+            dgv = new DataGridView
+            {
+                Dock = DockStyle.Fill,
+                ReadOnly = true,
+                AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.Fill
+            };
+            Controls.Add(dgv);
+        }
+
+        private void CargarHospitalizaciones()
+        {
+            using (var ctx = new ClinicaContext())
+            {
+                var lista = ctx.Hospitalizaciones
+                    .Select(h => new { h.HospitalizacionId, h.PacienteId, h.HabitacionId, h.FechaIngreso, h.FechaAlta, h.Estado })
+                    .ToList();
+                dgv.DataSource = lista;
+            }
         }
     }
 }
-

--- a/Roles/Admin/Personal/FormGestionPersonal.cs
+++ b/Roles/Admin/Personal/FormGestionPersonal.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Windows.Forms;
 using MiSalud.Datos;                        // Tu DbContext (ClinicaContext)
 using Entidades = MiSalud.Entidades;       // Alias para acceder a tus clases del namespace Entidades
+using MiSalud.Utilidades;
 
 namespace MiSalud.Roles.Admin.Personal
 {
@@ -189,7 +190,7 @@ namespace MiSalud.Roles.Admin.Personal
                             Rol = cbRol.Text,
                             EspecialidadId = Convert.ToInt32(cbEspecialidad.SelectedValue),
                             Usuario = txtUsuario.Text,
-                            Contrasena = txtContrasena.Text,
+                            Contrasena = Seguridad.HashPassword(txtContrasena.Text),
                             FechaCreacion = dtpCreacion.Value,
                             Estado = chkEstado.Checked
                         };
@@ -218,7 +219,10 @@ namespace MiSalud.Roles.Admin.Personal
                             personal.Rol = cbRol.Text;
                             personal.EspecialidadId = Convert.ToInt32(cbEspecialidad.SelectedValue);
                             personal.Usuario = txtUsuario.Text;
-                            personal.Contrasena = txtContrasena.Text;
+                            if (!string.IsNullOrWhiteSpace(txtContrasena.Text))
+                            {
+                                personal.Contrasena = Seguridad.HashPassword(txtContrasena.Text);
+                            }
                             personal.FechaCreacion = dtpCreacion.Value;
                             personal.Estado = chkEstado.Checked;
 

--- a/Roles/Admin/PlanesPago/FormPlanesPago.cs
+++ b/Roles/Admin/PlanesPago/FormPlanesPago.cs
@@ -1,10 +1,14 @@
-﻿using System;
+using System;
+using System.Linq;
 using System.Windows.Forms;
+using MiSalud.Datos;
 
 namespace MiSalud.Roles.Admin.PlanesPago
 {
     public partial class FormPlanesPago : Form
     {
+        private DataGridView dgv;
+
         public FormPlanesPago()
         {
             InitializeComponent();
@@ -14,7 +18,30 @@ namespace MiSalud.Roles.Admin.PlanesPago
         {
             this.BackColor = System.Drawing.Color.White;
             this.Dock = DockStyle.Fill;
+            InicializarControles();
+            CargarPlanes();
+        }
+
+        private void InicializarControles()
+        {
+            dgv = new DataGridView
+            {
+                Dock = DockStyle.Fill,
+                ReadOnly = true,
+                AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.Fill
+            };
+            Controls.Add(dgv);
+        }
+
+        private void CargarPlanes()
+        {
+            using (var ctx = new ClinicaContext())
+            {
+                var lista = ctx.PlanesPago
+                    .Select(p => new { p.PlanPagoId, p.FacturaId, p.MontoTotal = p.MontoTotal, p.Estado })
+                    .ToList();
+                dgv.DataSource = lista;
+            }
         }
     }
 }
-

--- a/Roles/Admin/Reportes/FormReportes.cs
+++ b/Roles/Admin/Reportes/FormReportes.cs
@@ -1,10 +1,13 @@
-﻿using System;
+using System;
 using System.Windows.Forms;
 
 namespace MiSalud.Roles.Admin.Reportes
 {
     public partial class FormReportes : Form
     {
+        private Label lblInfo;
+        private DataGridView dgvResumen;
+
         public FormReportes()
         {
             InitializeComponent();
@@ -14,7 +17,39 @@ namespace MiSalud.Roles.Admin.Reportes
         {
             this.BackColor = System.Drawing.Color.White;
             this.Dock = DockStyle.Fill;
+            lblInfo = new Label { Text = "Atenciones por mes", AutoSize = true, Top = 60, Left = 20 };
+            dgvResumen = new DataGridView
+            {
+                Top = 90,
+                Left = 20,
+                Width = 400,
+                Height = 250,
+                ReadOnly = true,
+                AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.Fill
+            };
+            Controls.Add(lblInfo);
+            Controls.Add(dgvResumen);
+
+            CargarResumen();
+        }
+
+        private void CargarResumen()
+        {
+            using (var ctx = new Datos.ClinicaContext())
+            {
+                var resumen = ctx.Consultas
+                    .GroupBy(c => new { c.FechaConsulta.Year, c.FechaConsulta.Month })
+                    .Select(g => new
+                    {
+                        Anio = g.Key.Year,
+                        Mes = g.Key.Month,
+                        Total = g.Count()
+                    })
+                    .OrderBy(r => r.Anio).ThenBy(r => r.Mes)
+                    .ToList();
+
+                dgvResumen.DataSource = resumen;
+            }
         }
     }
 }
-

--- a/Roles/Admin/Servicios/FormGestionServicios.cs
+++ b/Roles/Admin/Servicios/FormGestionServicios.cs
@@ -1,10 +1,23 @@
-﻿using System;
+using System;
+using System.Linq;
 using System.Windows.Forms;
+using MiSalud.Datos;
+using Entidades = MiSalud.Entidades;
 
 namespace MiSalud.Roles.Admin.Servicios
 {
     public partial class FormGestionServicios : Form
     {
+        private DataGridView dgv;
+        private TextBox txtNombre;
+        private TextBox txtDescripcion;
+        private NumericUpDown numCosto;
+        private CheckBox chkRequiere;
+        private Button btnGuardar;
+        private Button btnEliminar;
+        private Button btnLimpiar;
+        private int? idSeleccionado = null;
+
         public FormGestionServicios()
         {
             InitializeComponent();
@@ -14,8 +27,146 @@ namespace MiSalud.Roles.Admin.Servicios
         {
             this.BackColor = System.Drawing.Color.White;
             this.Dock = DockStyle.Fill;
+            InicializarControles();
+            CargarServicios();
+        }
+
+        private void InicializarControles()
+        {
+            dgv = new DataGridView
+            {
+                Dock = DockStyle.Bottom,
+                Height = 250,
+                ReadOnly = true,
+                AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.Fill
+            };
+            dgv.CellDoubleClick += Dgv_CellDoubleClick;
+
+            var lblNombre = new Label { Text = "Nombre", Top = 60, Left = 20 };
+            txtNombre = new TextBox { Top = 80, Left = 20, Width = 200 };
+            var lblDescripcion = new Label { Text = "Descripción", Top = 110, Left = 20 };
+            txtDescripcion = new TextBox { Top = 130, Left = 20, Width = 300 };
+            var lblCosto = new Label { Text = "Costo", Top = 160, Left = 20 };
+            numCosto = new NumericUpDown { Top = 180, Left = 20, Width = 100, DecimalPlaces = 2, Maximum = 10000 };
+            chkRequiere = new CheckBox { Text = "Requiere prescripción", Top = 210, Left = 20 };
+
+            btnGuardar = new Button { Text = "Guardar", Top = 240, Left = 20 };
+            btnGuardar.Click += BtnGuardar_Click;
+            btnEliminar = new Button { Text = "Eliminar", Top = 240, Left = 120 };
+            btnEliminar.Click += BtnEliminar_Click;
+            btnLimpiar = new Button { Text = "Limpiar", Top = 240, Left = 220 };
+            btnLimpiar.Click += BtnLimpiar_Click;
+
+            Controls.AddRange(new Control[]
+            {
+                lblNombre, txtNombre, lblDescripcion, txtDescripcion,
+                lblCosto, numCosto, chkRequiere,
+                btnGuardar, btnEliminar, btnLimpiar, dgv
+            });
+        }
+
+        private void BtnGuardar_Click(object sender, EventArgs e)
+        {
+            if (string.IsNullOrWhiteSpace(txtNombre.Text))
+            {
+                MessageBox.Show("El nombre es obligatorio");
+                return;
+            }
+
+            using (var ctx = new ClinicaContext())
+            {
+                if (idSeleccionado == null)
+                {
+                    var s = new Entidades.Servicio
+                    {
+                        Nombre = txtNombre.Text,
+                        Descripcion = txtDescripcion.Text,
+                        Costo = numCosto.Value,
+                        RequierePrescripcion = chkRequiere.Checked,
+                        FechaCreacion = DateTime.Now,
+                        Estado = true
+                    };
+                    ctx.Servicios.Add(s);
+                    ctx.SaveChanges();
+                }
+                else
+                {
+                    var serv = ctx.Servicios.FirstOrDefault(x => x.ServicioId == idSeleccionado);
+                    if (serv != null)
+                    {
+                        serv.Nombre = txtNombre.Text;
+                        serv.Descripcion = txtDescripcion.Text;
+                        serv.Costo = numCosto.Value;
+                        serv.RequierePrescripcion = chkRequiere.Checked;
+                        ctx.SaveChanges();
+                    }
+                }
+            }
+
+            Limpiar();
+            CargarServicios();
+        }
+
+        private void BtnEliminar_Click(object sender, EventArgs e)
+        {
+            if (idSeleccionado == null)
+            {
+                MessageBox.Show("Selecciona un registro");
+                return;
+            }
+
+            using (var ctx = new ClinicaContext())
+            {
+                var serv = ctx.Servicios.FirstOrDefault(x => x.ServicioId == idSeleccionado);
+                if (serv != null)
+                {
+                    ctx.Servicios.Remove(serv);
+                    ctx.SaveChanges();
+                }
+            }
+
+            Limpiar();
+            CargarServicios();
+        }
+
+        private void BtnLimpiar_Click(object sender, EventArgs e)
+        {
+            Limpiar();
+        }
+
+        private void Dgv_CellDoubleClick(object sender, DataGridViewCellEventArgs e)
+        {
+            if (e.RowIndex >= 0)
+            {
+                var fila = dgv.Rows[e.RowIndex];
+                idSeleccionado = Convert.ToInt32(fila.Cells["ServicioId"].Value);
+                txtNombre.Text = fila.Cells["Nombre"].Value?.ToString();
+                txtDescripcion.Text = fila.Cells["Descripcion"].Value?.ToString();
+                numCosto.Value = Convert.ToDecimal(fila.Cells["Costo"].Value);
+                chkRequiere.Checked = Convert.ToBoolean(fila.Cells["RequierePrescripcion"].Value);
+                btnGuardar.Text = "Actualizar";
+            }
+        }
+
+        private void CargarServicios()
+        {
+            using (var ctx = new ClinicaContext())
+            {
+                var lista = ctx.Servicios
+                    .Select(s => new { s.ServicioId, s.Nombre, s.Descripcion, s.Costo, s.RequierePrescripcion })
+                    .ToList();
+                dgv.DataSource = lista;
+            }
+        }
+
+        private void Limpiar()
+        {
+            txtNombre.Text = string.Empty;
+            txtDescripcion.Text = string.Empty;
+            numCosto.Value = 0;
+            chkRequiere.Checked = false;
+            btnGuardar.Text = "Guardar";
+            idSeleccionado = null;
         }
     }
 }
-
-

--- a/Roles/Admin/Servicios/FormGestionServicios.cs
+++ b/Roles/Admin/Servicios/FormGestionServicios.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Windows.Forms;
 using MiSalud.Datos;
+using MiSalud.Utilidades;
 using Entidades = MiSalud.Entidades;
 
 namespace MiSalud.Roles.Admin.Servicios
@@ -88,6 +89,7 @@ namespace MiSalud.Roles.Admin.Servicios
                     };
                     ctx.Servicios.Add(s);
                     ctx.SaveChanges();
+                    Utilidades.AuditoriaLogger.Registrar(Login.SelectorRoles.UsuarioActual, "Servicios", "Crear", $"Servicio {s.Nombre}");
                 }
                 else
                 {
@@ -99,6 +101,7 @@ namespace MiSalud.Roles.Admin.Servicios
                         serv.Costo = numCosto.Value;
                         serv.RequierePrescripcion = chkRequiere.Checked;
                         ctx.SaveChanges();
+                        Utilidades.AuditoriaLogger.Registrar(Login.SelectorRoles.UsuarioActual, "Servicios", "Actualizar", $"Servicio {serv.Nombre}");
                     }
                 }
             }
@@ -122,6 +125,7 @@ namespace MiSalud.Roles.Admin.Servicios
                 {
                     ctx.Servicios.Remove(serv);
                     ctx.SaveChanges();
+                    Utilidades.AuditoriaLogger.Registrar(Login.SelectorRoles.UsuarioActual, "Servicios", "Eliminar", $"Servicio {serv.Nombre}");
                 }
             }
 

--- a/Roles/Admin/Usuarios/FormGestionUsuarios.Designer.cs
+++ b/Roles/Admin/Usuarios/FormGestionUsuarios.Designer.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace MiSalud.Roles.Admin.Usuarios
+{
+    partial class FormGestionUsuarios
+    {
+        private System.ComponentModel.IContainer components = null;
+        private Label labelTitulo;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+                components.Dispose();
+            base.Dispose(disposing);
+        }
+
+        private void InitializeComponent()
+        {
+            this.labelTitulo = new Label();
+            this.SuspendLayout();
+            this.labelTitulo.Dock = DockStyle.Top;
+            this.labelTitulo.Font = new Font("Segoe UI", 18F, FontStyle.Bold, GraphicsUnit.Point);
+            this.labelTitulo.ForeColor = Color.FromArgb(30, 60, 114);
+            this.labelTitulo.Location = new Point(0, 0);
+            this.labelTitulo.Name = "labelTitulo";
+            this.labelTitulo.Size = new Size(800, 50);
+            this.labelTitulo.TabIndex = 0;
+            this.labelTitulo.Text = "GESTIÓN DE USUARIOS";
+            this.labelTitulo.TextAlign = ContentAlignment.MiddleCenter;
+
+            this.AutoScaleMode = AutoScaleMode.None;
+            this.ClientSize = new Size(800, 500);
+            this.Controls.Add(this.labelTitulo);
+            this.FormBorderStyle = FormBorderStyle.None;
+            this.Name = "FormGestionUsuarios";
+            this.Load += new EventHandler(this.FormGestionUsuarios_Load);
+            this.ResumeLayout(false);
+        }
+    }
+}

--- a/Roles/Admin/Usuarios/FormGestionUsuarios.cs
+++ b/Roles/Admin/Usuarios/FormGestionUsuarios.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Linq;
+using System.Windows.Forms;
+using MiSalud.Datos;
+using MiSalud.Utilidades;
+
+namespace MiSalud.Roles.Admin.Usuarios
+{
+    public partial class FormGestionUsuarios : Form
+    {
+        private DataGridView dgv;
+        private TextBox txtUsuario;
+        private TextBox txtContrasena;
+        private ComboBox cbRol;
+        private CheckBox chkActivo;
+        private Button btnGuardar;
+        private int? idSeleccionado = null;
+
+        public FormGestionUsuarios()
+        {
+            InitializeComponent();
+        }
+
+        private void FormGestionUsuarios_Load(object sender, EventArgs e)
+        {
+            this.BackColor = System.Drawing.Color.White;
+            this.Dock = DockStyle.Fill;
+            InicializarControles();
+            CargarUsuarios();
+        }
+
+        private void InicializarControles()
+        {
+            dgv = new DataGridView
+            {
+                Dock = DockStyle.Bottom,
+                Height = 250,
+                ReadOnly = true,
+                AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.Fill
+            };
+            dgv.CellDoubleClick += Dgv_CellDoubleClick;
+
+            var lblUsuario = new Label { Text = "Usuario", Top = 60, Left = 20 };
+            txtUsuario = new TextBox { Top = 80, Left = 20, Width = 200, ReadOnly = true };
+            var lblContrasena = new Label { Text = "Nueva contraseña", Top = 110, Left = 20 };
+            txtContrasena = new TextBox { Top = 130, Left = 20, Width = 200 };
+            var lblRol = new Label { Text = "Rol", Top = 160, Left = 20 };
+            cbRol = new ComboBox { Top = 180, Left = 20, Width = 200, DropDownStyle = ComboBoxStyle.DropDownList };
+            cbRol.Items.AddRange(new object[] { "Administrador", "Doctor", "Enfermería", "Caja" });
+            chkActivo = new CheckBox { Text = "Activo", Top = 210, Left = 20 };
+
+            btnGuardar = new Button { Text = "Guardar", Top = 240, Left = 20 };
+            btnGuardar.Click += BtnGuardar_Click;
+
+            Controls.AddRange(new Control[]
+            {
+                lblUsuario, txtUsuario, lblContrasena, txtContrasena,
+                lblRol, cbRol, chkActivo, btnGuardar, dgv
+            });
+        }
+
+        private void Dgv_CellDoubleClick(object sender, DataGridViewCellEventArgs e)
+        {
+            if (e.RowIndex >= 0)
+            {
+                var fila = dgv.Rows[e.RowIndex];
+                idSeleccionado = Convert.ToInt32(fila.Cells["PersonalId"].Value);
+                txtUsuario.Text = fila.Cells["Usuario"].Value.ToString();
+                cbRol.SelectedItem = fila.Cells["Rol"].Value.ToString();
+                chkActivo.Checked = Convert.ToBoolean(fila.Cells["Estado"].Value);
+                txtContrasena.Text = string.Empty;
+            }
+        }
+
+        private void BtnGuardar_Click(object sender, EventArgs e)
+        {
+            if (idSeleccionado == null)
+            {
+                MessageBox.Show("Selecciona un usuario de la lista");
+                return;
+            }
+
+            using (var ctx = new ClinicaContext())
+            {
+                var usuario = ctx.Personal.FirstOrDefault(p => p.PersonalId == idSeleccionado);
+                if (usuario != null)
+                {
+                    if (!string.IsNullOrWhiteSpace(txtContrasena.Text))
+                    {
+                        usuario.Contrasena = Seguridad.HashPassword(txtContrasena.Text);
+                    }
+                    if (cbRol.SelectedItem != null)
+                        usuario.Rol = cbRol.SelectedItem.ToString();
+                    usuario.Estado = chkActivo.Checked;
+                    ctx.SaveChanges();
+                }
+            }
+
+            txtContrasena.Text = string.Empty;
+            idSeleccionado = null;
+            CargarUsuarios();
+        }
+
+        private void CargarUsuarios()
+        {
+            using (var ctx = new ClinicaContext())
+            {
+                var lista = ctx.Personal
+                    .Select(p => new { p.PersonalId, p.Usuario, p.Rol, p.Estado })
+                    .ToList();
+                dgv.DataSource = lista;
+            }
+        }
+    }
+}

--- a/Roles/Admin/Usuarios/FormGestionUsuarios.resx
+++ b/Roles/Admin/Usuarios/FormGestionUsuarios.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/Utilidades/AuditoriaLogger.cs
+++ b/Utilidades/AuditoriaLogger.cs
@@ -1,0 +1,31 @@
+using System;
+using MiSalud.Datos;
+using MiSalud.Entidades;
+
+namespace MiSalud.Utilidades
+{
+    public static class AuditoriaLogger
+    {
+        public static void Registrar(string usuario, string tabla, string accion, string detalle)
+        {
+            try
+            {
+                using var ctx = new ClinicaContext();
+                var registro = new Auditoria
+                {
+                    Usuario = usuario,
+                    Tabla = tabla,
+                    Accion = accion,
+                    Detalle = detalle,
+                    Fecha = DateTime.Now
+                };
+                ctx.Auditoria.Add(registro);
+                ctx.SaveChanges();
+            }
+            catch
+            {
+                // en escenarios de auditoría, nunca se debe lanzar excepción al usuario
+            }
+        }
+    }
+}

--- a/Utilidades/Seguridad.cs
+++ b/Utilidades/Seguridad.cs
@@ -1,0 +1,16 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace MiSalud.Utilidades
+{
+    public static class Seguridad
+    {
+        public static string HashPassword(string password)
+        {
+            using var sha = SHA256.Create();
+            var bytes = Encoding.UTF8.GetBytes(password);
+            var hash = sha.ComputeHash(bytes);
+            return Convert.ToHexString(hash);
+        }
+    }
+}

--- a/appsettings.json
+++ b/appsettings.json
@@ -1,0 +1,5 @@
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "Host=localhost;Database=MiSalud;Username=postgres;Password=1234"
+  }
+}


### PR DESCRIPTION
## Summary
- add a `Seguridad` helper to hash passwords using SHA256
- validate credentials using password hashes
- store hashed passwords when creating or updating staff accounts

## Testing
- `dotnet build -c Release` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6841bb9dba1c8331bdb039acacf3806d